### PR TITLE
adds env prop to use development environment

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 build/
 dist/
 node_modules/
+example/
 .snapshots/
 *.min.js

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What changed
+<!-- Describe what changed in this PR (not how it was implemented). -->
+
+## Why it changed
+<!-- Explain the reason for this change (bug, feature, refactor, etc.). -->
+
+## How to test
+<!-- Steps for reviewers to verify the change. -->
+
+---
+- [ ] PR title describes **what** changed, not how
+- [ ] Branch will be deleted after merge

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react": "^19.0.0"
   },
   "devDependencies": {
+    "@rushstack/eslint-patch": "^1.10.0",
     "microbundle-crl": "^0.13.10",
     "babel-eslint": "^10.0.3",
     "cross-env": "^7.0.2",

--- a/src/lib/Dojah.js
+++ b/src/lib/Dojah.js
@@ -23,8 +23,11 @@ class Dojah extends Component {
   }
 
   start = () => {
-    const { response } = this.props
-    let { uri } = Dojah.config
+    const { response, env } = this.props
+    let uri =
+      env === 'development'
+        ? 'https://dev-widget.dojah.services/widget.js'
+        : Dojah.config.uri
     if (window.dojah && window.dojah.uri) {
       uri = window.dojah.uri
     }
@@ -97,7 +100,8 @@ Dojah.propTypes = {
   appID: PropTypes.string.isRequired,
   publicKey: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
-  response: PropTypes.func.isRequired
+  response: PropTypes.func.isRequired,
+  env: PropTypes.string
 }
 
 export default Dojah


### PR DESCRIPTION
## What changed
optional prop 'env' added to allow use of dev environment

## Why it changed
to allow tests on dev environment

## How to test
add env='development' as a prop

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds optional `env` prop to `Dojah` component for development environment support and a PR template.
> 
>   - **Behavior**:
>     - Adds optional `env` prop to `Dojah` component in `Dojah.js` to use development environment URI.
>     - In `start()` function, sets `uri` to `https://dev-widget.dojah.services/widget.js` if `env` is 'development'.
>   - **Misc**:
>     - Adds `.github/PULL_REQUEST_TEMPLATE.md` for PR guidelines.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dojah-inc%2FReact-Js-sdk&utm_source=github&utm_medium=referral)<sup> for 2b823bc77b32b6f925e24b43cf48875ecc58fb6c. You can [customize](https://app.ellipsis.dev/dojah-inc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->